### PR TITLE
I've enabled generic input for the HITL node.

### DIFF
--- a/examples/run_tool.py
+++ b/examples/run_tool.py
@@ -40,9 +40,7 @@ import json # For loading data and printing results
 try:
     # This will work if the package is installed (e.g., via pip install -e .)
     # or if the top-level project directory is in PYTHONPATH.
-    # This will work if the package is installed (e.g., via pip install -e .)
-    # or if the top-level project directory is in PYTHONPATH.
-    from themule_atomic_hitl.runner import hitl_node_run
+    from themule_atomic_hitl import hitl_node_run
     from themule_atomic_hitl.config import Config
     from themule_atomic_hitl.logging_config import setup_logging
     logging.debug("Imported themule_atomic_hitl components directly.")
@@ -56,7 +54,7 @@ except ImportError as e_installed:
         logging.debug(f"Added project root to sys.path: {project_root}")
 
     try:
-        from src.themule_atomic_hitl.runner import hitl_node_run
+        from src.themule_atomic_hitl import hitl_node_run
         from src.themule_atomic_hitl.config import Config # Though hitl_node_run handles Config internally
         from src.themule_atomic_hitl.logging_config import setup_logging
         logging.debug("Successfully imported components via 'src.' prefix after path adjustment.")

--- a/src/themule_atomic_hitl/runner.py
+++ b/src/themule_atomic_hitl/runner.py
@@ -84,12 +84,12 @@ class Backend(QObject):
     # Signal to indicate session termination, so the calling function can retrieve data
     sessionTerminatedSignal = pyqtSignal()
 
-    def __init__(self, initial_data: Dict[str, Any], config_manager: Config, parent: Optional[QObject] = None):
+    def __init__(self, initial_data: Union[Dict[str, Any], str], config_manager: Config, parent: Optional[QObject] = None):
         """
         Initializes the Backend object.
 
         Args:
-            initial_data (Dict[str, Any]): The initial data for the editor.
+            initial_data (Union[Dict[str, Any], str]): The initial data for the editor.
             config_manager (Config): The Config object containing configuration settings.
             parent (Optional[QObject]): The parent QObject, if any.
         """
@@ -319,7 +319,7 @@ class MainWindow(QMainWindow):
     It initializes the Backend, QWebChannel, and loads the frontend HTML.
     """
     def __init__(self,
-                 initial_data: Dict[str, Any],
+                 initial_data: Union[Dict[str, Any], str],
                  config_dict_param: Dict[str, Any], # Changed
                  app_instance: QApplication, # Expects the QApplication instance
                  parent: Optional[QObject] = None):
@@ -328,7 +328,7 @@ class MainWindow(QMainWindow):
         Initializes the MainWindow.
 
         Args:
-            initial_data (Dict[str, Any]): The initial data for the editor.
+            initial_data (Union[Dict[str, Any], str]): The initial data for the editor.
             config_dict_param (Dict[str, Any]): The configuration dictionary. # Changed
             app_instance (QApplication): The current QApplication instance.
             parent (Optional[QObject]): The parent QObject, if any.
@@ -392,7 +392,7 @@ class MainWindow(QMainWindow):
 # The _load_json_file helper is at the top of the file.
 # It's renamed from _load_data_file (my version) to _load_json_file (main's version) for consistency.
 
-def run_application(initial_data_param: Dict[str, Any],
+def run_application(initial_data_param: Union[Dict[str, Any], str],
                       config_param_dict: Dict[str, Any], # Changed
                       qt_app: Optional[QApplication] = None) -> Optional[Union[Dict[str,Any], QMainWindow]]:
     """

--- a/src/themule_atomic_hitl/terminal_main.py
+++ b/src/themule_atomic_hitl/terminal_main.py
@@ -3,7 +3,7 @@ import logging
 import os
 import sys
 import json
-from typing import Dict, Any
+from typing import Dict, Any, Union
 
 # It's good practice to set up logging at the very beginning.
 # This will catch logs from all imported modules.
@@ -27,16 +27,26 @@ except ImportError:
     # from terminal_interface import run_terminal_interface
 
 
-def _load_json_file(path: str) -> Dict[str, Any]:
+def _load_data_from_file(path: str) -> Union[Dict[str, Any], str]:
     """
-    Helper function to load data from a JSON file.
+    Helper function to load data from a file.
+    It tries to load the file as JSON, but if it fails, it returns the content as a raw string.
     """
     try:
         with open(path, 'r', encoding='utf-8') as f:
-            return json.load(f)
-    except (FileNotFoundError, json.JSONDecodeError) as e:
-        logging.error(f"Error loading JSON from {path}: {e}")
-        return {}
+            try:
+                # First, try to load as JSON
+                return json.load(f)
+            except json.JSONDecodeError:
+                # If JSON decoding fails, reset cursor and read as plain text
+                f.seek(0)
+                return f.read()
+    except FileNotFoundError:
+        logging.error(f"Error: File not found at {path}")
+        return "" # Return empty string for not found
+    except Exception as e:
+        logging.error(f"An unexpected error occurred while reading {path}: {e}")
+        return "" # Return empty string for other errors
 
 def main():
     """
@@ -73,13 +83,18 @@ def main():
         app_config = Config()
 
     # --- Initial Data Loading ---
-    initial_app_data = None
+    initial_app_data = "" # Default to empty string
     if args.data:
-        initial_app_data = _load_json_file(args.data)
+        initial_app_data = _load_data_from_file(args.data)
 
     if not initial_app_data:
-        logging.warning("No initial data file provided or file is empty. Using minimal default data.")
-        # Use main_editor_modified_field from config to structure default data
+        logging.warning("No initial data provided or file is empty. Using minimal default data.")
+        # If the data is still empty (e.g., file not found, or empty file),
+        # we create a default dictionary.
+        # This part is tricky because the HITL node now expects either a string or a dict.
+        # If we provide a dict, it will be used directly. If we provide a string, it will be wrapped.
+        # For the terminal_main, let's decide if we want to proceed with a default string or a default dict.
+        # A default dict is more structured and aligns with the previous behavior.
         m_field = app_config.main_editor_modified_field
         o_field = app_config.main_editor_original_field
         initial_app_data = {
@@ -99,15 +114,21 @@ def main():
         logging.warning("Terminal interface is not yet implemented.")
 
     else:
+        from .hitl_node import hitl_node_run
         logging.info("Starting in GUI Mode...")
-        # We need to get the config as a dictionary for the runner
-        config_dict = app_config.get_config()
-        # The run_application function from runner.py will handle the GUI
-        final_data = run_application(initial_app_data, config_dict, qt_app=None)
+        # The hitl_node_run function now encapsulates the logic for preparing data and running the app
+        final_data = hitl_node_run(
+            content_to_review=initial_app_data,
+            custom_config_path=args.config,
+            # In terminal_main, we are not integrating into an existing Qt app,
+            # so we pass None for existing_qt_app.
+            existing_qt_app=None
+        )
 
         logging.info("\n--- GUI session finished ---")
         if final_data:
             logging.info("Final data returned:")
+            # We can use json.dumps to pretty-print the final dictionary
             logging.info(json.dumps(final_data, indent=2))
 
 if __name__ == '__main__':


### PR DESCRIPTION
This change modifies the HITL node to accept any file type as input, not just structured JSON.

I've modified the following files:
- `terminal_main.py`: Reads any file and passes the content to the `hitl_node`.
- `hitl_node.py`: Accepts both raw text and dictionaries.
- `runner.py`: Handles generic data passed from `hitl_node.py`.
- `core.py`: Handles generic data in the `SurgicalEditorLogic` class.
- `examples/run_tool.py`: Updated to use the correct entry point.

This makes the HITL node more flexible and allows it to be used in a wider range of scenarios where the input might not be a JSON object.