### PR TITLE
Fix missing confirmation UI

### DIFF
--- a/src/themule_atomic_hitl/frontend/frontend.js
+++ b/src/themule_atomic_hitl/frontend/frontend.js
@@ -88,17 +88,20 @@ function renderConfigurableUI() {
     // If the container exists,
     if (container) {
         // If the container is the main body and there's a main diff editor element,
-        if (id === 'mainbody-container' && mainDiffEditorElement) {
-            // remove all children of the container except the main diff editor element and some other specific elements.
+        if (id === 'mainbody-container') {
+            // Remove all children except the diff editor (if present) and the HITL sections.
             Array.from(container.childNodes).forEach(child => {
-                if (child !== mainDiffEditorElement && !mainDiffEditorElement.contains(child) &&
-                    child.id !== 'location-confirmation-area' && child.id !== 'inner-loop-decision-area') {
+                const preserve = (child === mainDiffEditorElement) ||
+                                 (mainDiffEditorElement && mainDiffEditorElement.contains(child)) ||
+                                 child.id === 'location-confirmation-area' ||
+                                 child.id === 'inner-loop-decision-area';
+                if (!preserve) {
                     container.removeChild(child);
                 }
             });
-        } else if (id !== 'mainbody-container' || (id === 'mainbody-container' && !mainDiffEditorElement) ) {
-             // Otherwise, clear the container's inner HTML.
-             container.innerHTML = ''; // Clear if not mainbody, or if mainbody without preserved editor
+        } else {
+            // For other containers simply clear their content.
+            container.innerHTML = '';
         }
     } else {
         // If the container doesn't exist, log a warning.


### PR DESCRIPTION
## Summary
- preserve location-confirmation-area and inner-loop-decision-area when rendering UI

## Testing
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_6882740fd1f48327b0da615905991e17