### PR TITLE
Improve snippet location workflow

### DIFF
--- a/src/themule_atomic_hitl/core.py
+++ b/src/themule_atomic_hitl/core.py
@@ -865,11 +865,18 @@ class SurgicalEditorLogic:
                 user_prompt=user_prompt_for_editor
             )
 
-            if edited_snippet is None: # Check if LLM returned None (e.g. error in service)
+            if edited_snippet is None:  # Check if LLM returned None (e.g. error in service)
                 self.callbacks['show_error']("LLM editor returned None. Using original snippet.")
                 return snippet_to_edit
 
-            return edited_snippet.strip() # Clean whitespace
+            # If structured output was returned, extract the edited text
+            if isinstance(edited_snippet, dict):
+                edited_snippet = edited_snippet.get("edited_text", json.dumps(edited_snippet))
+
+            if not isinstance(edited_snippet, str):
+                edited_snippet = str(edited_snippet)
+
+            return edited_snippet.strip()  # Clean whitespace
 
         except Exception as e:
             self.callbacks['show_error'](f"Error during LLM edit: {str(e)}")

--- a/src/themule_atomic_hitl/frontend/index.html
+++ b/src/themule_atomic_hitl/frontend/index.html
@@ -172,6 +172,11 @@
       animation: spin 1s linear infinite;
       margin-left: 15px; /* Space from queue status */
     }
+
+    /* Highlight style for located snippets */
+    .llm-snippet-highlight {
+      background-color: #fff3cd;
+    }
     @keyframes spin {
       0% { transform: rotate(0deg); }
       100% { transform: rotate(360deg); }
@@ -258,6 +263,7 @@
             <label for="input-revised-hint">Revise Hint (optional, if LLM missed the spot):</label>
             <input type="text" id="input-revised-hint"> <!-- Allows user to provide a corrected hint -->
         </div>
+        <button id="btn-reprocess-location" class="action-button">Resubmit Revised Hint</button>
         <button id="btn-confirm-location" class="action-button primary">Confirm Location & Proceed with Edit</button>
         <button id="btn-cancel-location-stage" class="action-button danger">Cancel This Edit Task</button>
       </div>

--- a/tests/test_core_logic.py
+++ b/tests/test_core_logic.py
@@ -311,5 +311,14 @@ class TestSurgicalEditorLogic(unittest.TestCase):
         self.assertEqual(self.editor_logic.data["version"], original_version_snapshot, "Version did not revert to initial state.")
         self.assertEqual(self.editor_logic.edit_results[-1]['status'], "action_revert_changes_success", "Revert action was not logged correctly.")
 
+    def test_08_retry_locator_with_new_hint(self):
+        """Tests reprocessing location with a revised hint during confirmation."""
+        self.editor_logic.add_edit_request(instruction="edit text", request_type="hint_based", hint="initial")
+        self.mock_callbacks['confirm_location_details'].assert_called_once()
+        # Simulate user requesting a new locator attempt with the same hint
+        self.editor_logic.retry_locator_with_new_hint("initial")
+        self.assertEqual(self.mock_callbacks['confirm_location_details'].call_count, 2)
+        self.assertEqual(self.editor_logic.active_edit_task['user_hint'], "initial")
+
 if __name__ == '__main__':
     unittest.main()


### PR DESCRIPTION
## Summary
- highlight located snippets inside the Monaco original editor
- allow resubmitting revised hints while confirming location
- fix location confirm serialization issue
- add cancellation method for early stages
- test retrying locator with a revised hint
- clear highlights when reprocessing a location hint

## Testing
- `pip install -r requirements.txt`
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_6883369e87888327820d35bba3fde21e